### PR TITLE
Rename to nitrokey-ci and introduce commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,16 +386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "github-comment"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "octocrab",
- "tokio",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +627,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nitrokey-ci"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "octocrab",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "github-comment"
+name = "nitrokey-ci"
 version = "0.1.0"
 edition = "2021"
 
 authors = ["Nitrokey GmbH <info@nitrokey.com>"]
-description = "CLI tool for interacting with the GitHub API"
+description = "CI tooling for the Nitrokey repositories"
 license = "Apache-2.0 or MIT"
 repository = "https://github.com/Nitrokey/github-comment"
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,15 @@
 # nitrokey-ci
 
-CI tooling for the Nitrokey repositories.
-
 ```
 $ nitrokey-ci --help
-Post or update a comment to a GitHub PR.
+CI tooling for the Nitrokey repositories
 
-This command tries to find a pull request that wants to merge the given commit.
-Then it checks if there is a comment that is tagged with the given ID. If yes,
-the comment is updated with the provided text. Otherwise, a new comment is
-created.
+Usage: nitrokey-ci <COMMAND>
 
-The GITHUB_COMMENT_TOKEN environment variable must be set to a token with the
-write permission for issues or pull requests on the target repository.
-
-Usage: nitrokey-ci --owner <OWNER> --repo <REPO> --commit <COMMIT> --id <ID> <TEXT>
-
-Arguments:
-  <TEXT>
-          A file containing the text of the comment
+Commands:
+  write-comment  Post or update a comment to a GitHub PR
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
-      --owner <OWNER>
-          The owner of the repository to post the comment to
-
-      --repo <REPO>
-          The repository to post the comment to
-
-      --commit <COMMIT>
-          The commit that should be used to identify the PR
-
-      --id <ID>
-          The ID of the comment that is embedded into the comment body
-
-  -h, --help
-          Print help (see a summary with '-h')
+  -h, --help  Print help
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# github-comment
+# nitrokey-ci
+
+CI tooling for the Nitrokey repositories.
 
 ```
-$ github-comment --help
+$ nitrokey-ci --help
 Post or update a comment to a GitHub PR.
 
 This command tries to find a pull request that wants to merge the given commit.
@@ -12,7 +14,7 @@ created.
 The GITHUB_COMMENT_TOKEN environment variable must be set to a token with the
 write permission for issues or pull requests on the target repository.
 
-Usage: github-comment --owner <OWNER> --repo <REPO> --commit <COMMIT> --id <ID> <TEXT>
+Usage: nitrokey-ci --owner <OWNER> --repo <REPO> --commit <COMMIT> --id <ID> <TEXT>
 
 Arguments:
   <TEXT>

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,17 +5,15 @@ use octocrab::{
     Octocrab,
 };
 
-use crate::args::Args;
-
-pub fn init(args: &Args, api_token: String) -> Result<Api> {
+pub fn init(owner: String, repo: String, api_token: String) -> Result<Api> {
     let octocrab = Octocrab::builder()
         .personal_token(api_token)
         .build()
         .context("failed to create API client")?;
     Ok(Api {
         octocrab,
-        owner: args.owner.clone(),
-        repo: args.repo.clone(),
+        owner,
+        repo,
     })
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,35 +1,47 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 pub fn parse() -> Args {
     Args::parse()
 }
 
-/// Post or update a comment to a GitHub PR.
-///
-/// This command tries to find a pull request that wants to merge the given commit. Then it checks
-/// if there is a comment that is tagged with the given ID. If yes, the comment is updated with the
-/// provided text. Otherwise, a new comment is created.
-///
-/// The GITHUB_COMMENT_TOKEN environment variable must be set to a token with the write permission
-/// for issues or pull requests on the target repository.
+/// CI tooling for the Nitrokey repositories.
 #[derive(Parser)]
 pub struct Args {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Post or update a comment to a GitHub PR.
+    ///
+    /// This command tries to find a pull request that wants to merge the given commit. Then it checks
+    /// if there is a comment that is tagged with the given ID. If yes, the comment is updated with the
+    /// provided text. Otherwise, a new comment is created.
+    ///
+    /// The GITHUB_COMMENT_TOKEN environment variable must be set to a token with the write permission
+    /// for issues or pull requests on the target repository.
+    WriteComment(WriteCommentArgs),
+}
+
+#[derive(clap::Args)]
+pub struct WriteCommentArgs {
     /// The owner of the repository to post the comment to.
-    #[clap(long)]
+    #[arg(long)]
     pub owner: String,
 
     /// The repository to post the comment to.
-    #[clap(long)]
+    #[arg(long)]
     pub repo: String,
 
     /// The commit that should be used to identify the PR.
-    #[clap(long)]
+    #[arg(long)]
     pub commit: String,
 
     /// The ID of the comment that is embedded into the comment body.
-    #[clap(long)]
+    #[arg(long)]
     pub id: String,
 
     /// A file containing the text of the comment.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,18 @@ use std::{env, fs};
 
 use anyhow::{Context as _, Result};
 
+use args::{Command, WriteCommentArgs};
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = args::parse();
+    match &args.command {
+        Command::WriteComment(args) => write_comment(&args),
+    }
+    .await
+}
+
+async fn write_comment(args: &WriteCommentArgs) -> Result<()> {
     let api_token = env::var("GITHUB_COMMENT_TOKEN")
         .context("GITHUB_COMMENT_TOKEN environment variable must contain a GitHub API token")?;
     let text = fs::read_to_string(&args.text).with_context(|| {
@@ -16,7 +25,7 @@ async fn main() -> Result<()> {
             args.text.display()
         )
     })?;
-    let api = api::init(&args, api_token)?;
+    let api = api::init(args.owner.clone(), args.repo.clone(), api_token)?;
     let pull_request = api.find_pull_request(&args.commit).await?;
     println!("Found pull request #{}", pull_request.number);
 


### PR DESCRIPTION
This PR renames `github-comment` to `nitrokey-ci` and moves the existing functionality into a subcommand.  This is a preparation for https://github.com/Nitrokey/github-comment/pull/1 which adds additional, more generic functionality to the tool.