### PR TITLE
fix command rights

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,15 +60,15 @@ async fn trigger_webhook_commands(
     api_token: String,
 ) -> Result<()> {
     let webhook = Webhook::parse(&args.webhook)?;
-    let commands = webhook_command_utils::extract_commands(&webhook, &args.bots);
+    let api = api::GitHubApi::init(&webhook.repo.owner, &webhook.repo.name, api_token)?;
+
+    let commands = webhook_command_utils::extract_commands(&webhook, &args.bots, &api).await?;
     if commands.is_empty() {
         println!("No commands found");
         return Ok(());
     }
 
     // get pull request and assosiated branch
-    let api = api::GitHubApi::init(&webhook.repo.owner, &webhook.repo.name, api_token)?;
-
     let pull_request = api.get_pull_request_by_id(webhook.issue_number).await?;
     let branch = pull_request.head.ref_field;
     println!("Found PR branch: {branch}");

--- a/test/webhook_test_data_edit_by_non_author.json
+++ b/test/webhook_test_data_edit_by_non_author.json
@@ -213,7 +213,7 @@
     "default_branch": "main"
   },
   "sender": {
-    "login": "authorlogin",
+    "login": "notauthorlogin",
     "id": 111111111,
     "node_id": "node_id",
     "avatar_url": "https://avatars.githubusercontent.com/u/111111111?v=4",


### PR DESCRIPTION
change way of getting repository rights for user to GitHub API

Currently only admins are accepted as everyone else is member in the webhook. 
Using the API it is possible to get exact repository roles.
Since we don't have a token in Actions testing this is not currently possible